### PR TITLE
[server][feature] Reduces memory allocations in renderer

### DIFF
--- a/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoublesImageRenderer.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoublesImageRenderer.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferInt;
 import java.util.Collections;
 import java.util.List;
 
@@ -100,10 +101,11 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
 			double maximumValue = getLevelExtrema(config).getSecond();
 
 			bi = new BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB);
+			int[] rgbArray = ((DataBufferInt)bi.getRaster().getDataBuffer()).getData();
 
 			@SuppressWarnings("unchecked")
 			ValueTransformer<Double> t = config.produce(ValueTransformer.class);
-			int[] rgbArray = new int[outputWidth*outputHeight];
+
 
 			double scaledLevelMaxFreq = t.transform(maximumValue)*rangeMax/100;
 			double scaledLevelMinFreq = t.transform(maximumValue)*rangeMin/100;
@@ -192,8 +194,6 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
 					}
 				}
 			}
-
-			bi.setRGB(0, 0, outputWidth, outputHeight, rgbArray, 0, outputWidth);
 		} catch (Exception e) {
 			LOGGER.warn("Tile is corrupt: " + layerId + ":" + index);
 			LOGGER.warn("Tile error: ", e);


### PR DESCRIPTION
Uses BufferedImage's internal int array instead of creating a new one. Removes a large array allocation and an array copy. Quick tests show a ~25% reduction in render time (not including tile request time).