### PR TITLE
Clean up after tests, fix pipeline tile set extension

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/TileOperations.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/TileOperations.scala
@@ -295,7 +295,7 @@ import scala.collection.JavaConversions._
                 yColSpec: String,
                 tilingParms: TilingTaskParameters)
                (input: PipelineData) = {
-    val tileIO = new LocalTileIO(".avro")
+    val tileIO = new LocalTileIO("avro")
     heatMapOpImpl(xColSpec, yColSpec, tilingParms, tileIO)(input)
   }
 

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
@@ -25,6 +25,8 @@
 package com.oculusinfo.tilegen.tiling
 
 
+import java.io.File
+
 import com.oculusinfo.tilegen.datasets.SchemaTypeUtilities
 import org.apache.spark.SharedSparkContext
 import org.apache.spark.sql.catalyst.types.StructType
@@ -245,39 +247,53 @@ class TestTileOperations extends FunSuite with SharedSparkContext {
   }
 
   test("Test file heatmap parse and operation") {
-    // pipeline stage to create test data
-    def createDataOp(count: Int)(input: PipelineData) = {
-      val jsonData = for (x <- 0 until count; y <- 0 until count if y % 2 == 0) yield s"""{"x":$x, "y":$y}\n"""
-      val srdd = sqlc.jsonRDD(sc.parallelize(jsonData))
-      PipelineData(sqlc, srdd)
+    try {
+      // pipeline stage to create test data
+      def createDataOp(count: Int)(input: PipelineData) = {
+        val jsonData = for (x <- 0 until count; y <- 0 until count if y % 2 == 0) yield s"""{"x":$x, "y":$y}\n"""
+        val srdd = sqlc.jsonRDD(sc.parallelize(jsonData))
+        PipelineData(sqlc, srdd)
+      }
+
+      // Run the tile job
+      val args = Map(
+        "ops.xColumn" -> "x",
+        "ops.yColumn" -> "y",
+        "ops.name" -> "test",
+        "ops.description" -> "a test description",
+        "ops.prefix" -> "test_prefix",
+        "ops.levels.0" -> "0,1",
+        "ops.tileWidth" -> "4",
+        "ops.tileHeight" -> "4")
+
+      val rootStage = PipelineStage("create_data", createDataOp(8)(_))
+      rootStage.addChild(PipelineStage("file_heatmap_op", parseFileHeatmapOp(args)))
+      TilePipelines.execute(rootStage, sqlc)
+
+      // Load the metadata and validate its contents - gives us an indication of whether or not the
+      // job completed successfully.
+      val tileIO = new LocalTileIO("avro")
+      val metaData = tileIO.readMetaData("test_prefix.test.x.y.count").getOrElse(fail("Metadata not created"))
+
+      val bounds = metaData.getBounds
+      assertResult(bounds.getMinX)(0.0)
+      assertResult(bounds.getMinY)(0.0)
+      assertResult(bounds.getMaxX)(7.0)
+      assertResult(bounds.getMaxY)(6.0)
+      val customMeta = metaData.getAllCustomMetaData
+      assertResult(customMeta.toString)("{0.minimum=0, global.minimum=0, global.maximum=2, 0.maximum=2, 1.minimum=0, 1.maximum=1}")
+    } finally {
+      // Remove the tile set we created
+      def removeRecursively (file: File): Unit = {
+        if (file.isDirectory) {
+          val list = file.list()
+          val files = file.listFiles()
+          file.listFiles().map(removeRecursively)
+        }
+        file.delete()
+      }
+      // If you want to look at the tile set (not remove it) comment out this line.
+      removeRecursively(new File("test_prefix.test.x.y.count"))
     }
-
-    // Run the tile job
-    val args = Map(
-      "ops.xColumn" -> "x",
-      "ops.yColumn" -> "y",
-      "ops.name" -> "test",
-      "ops.description" -> "a test description",
-      "ops.prefix" -> "test_prefix",
-      "ops.levels.0" -> "0,1",
-      "ops.tileWidth" -> "4",
-      "ops.tileHeight" -> "4")
-
-    val rootStage = PipelineStage("create_data", createDataOp(8)(_))
-    rootStage.addChild(PipelineStage("file_heatmap_op", parseFileHeatmapOp(args)))
-    TilePipelines.execute(rootStage, sqlc)
-
-    // Load the metadata and validate its contents - gives us an indication of whether or not the
-    // job completed successfully.
-    val tileIO = new LocalTileIO(".avro")
-    val metaData = tileIO.readMetaData("test_prefix.test.x.y.count").getOrElse(fail("Metadata not created"))
-
-    val bounds = metaData.getBounds
-    assertResult(bounds.getMinX)(0.0)
-    assertResult(bounds.getMinY)(0.0)
-    assertResult(bounds.getMaxX)(7.0)
-    assertResult(bounds.getMaxY)(6.0)
-    val customMeta = metaData.getAllCustomMetaData
-    assertResult(customMeta.toString)("{0.minimum=0, global.minimum=0, global.maximum=2, 0.maximum=2, 1.minimum=0, 1.maximum=1}")
   }
 }


### PR DESCRIPTION
Remove test-created tile set when done tests
When creating a tile set via the tile pipeline, files were being written as "1..avro" instead of "1.avro".