### PR TITLE
Tile operation unique table names

### DIFF
--- a/binning-utilities/build.gradle
+++ b/binning-utilities/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	compile "org.xerial:sqlite-jdbc:3.7.2"
 	compile "com.esotericsoftware.kryo:kryo:2.21"
 	compile "org.slf4j:slf4j-api:1.7.5"
+	compile "com.google.guava:guava:14.0.1"
 	testCompile "junit:junit:4.8.1"
 
 	// Call to special handling for hbase dependencies - see top level build file for

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
@@ -89,8 +89,7 @@ class TestTileOperations extends FunSuite with SharedSparkContext {
 
 		assertResult(List(
 			"one", "2015-01-01 10:15:30",
-			"two", "2015-01-02 8:15:30" +
-				"",
+			"two", "2015-01-02 8:15:30",
 			"three", "2015-01-03 10:15:30"))(resultList.toList)
 	}
 

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/TileOperationsTests.scala
@@ -89,7 +89,8 @@ class TestTileOperations extends FunSuite with SharedSparkContext {
 
 		assertResult(List(
 			"one", "2015-01-01 10:15:30",
-			"two", "2015-01-02 8:15:30",
+			"two", "2015-01-02 8:15:30" +
+				"",
 			"three", "2015-01-03 10:15:30"))(resultList.toList)
 	}
 


### PR DESCRIPTION
* Factors the logic to generate a unique table name out of the cache operation, and updates both caching and heatmap ops to use the new function.
* Fixes a guava version conflict that both @nkronenfeld and I ran into when running test cases