### PR TITLE
Improved error handling during CSV reading

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/CSVReader.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/CSVReader.scala
@@ -27,11 +27,11 @@ package com.oculusinfo.tilegen.datasets
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.util.TimeZone
-
 import com.oculusinfo.tilegen.util.KeyValueArgumentSource
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
+import scala.util.Try
 
 /**
  * A class that allows reading a schema file and a CSV file as a SchemaRDD.
@@ -131,12 +131,12 @@ class CSVReader (val sqlc: SQLContext, data: RDD[String], configuration: KeyValu
 		val indices = _indices
 		val N = _fields
 		val rowRDD: RDD[Row] = data.map(record =>
-			{
+			Try{
 				val fields = record.split(separator)
 				val values = (0 until N).map(n => parsers(n)(fields(indices(n))))
 				row(values:_*)
 			}
-		)
+		).filter(_.isSuccess).map(_.get)
 		sqlc.applySchema(rowRDD, _schema)
 	}
 

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/binning/OnDemandTileTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/binning/OnDemandTileTests.scala
@@ -71,8 +71,14 @@ class LiveTileTestSuite extends FunSuite with SharedSparkContext with BeforeAndA
 		dataFile1 = File.createTempFile("simple-live-tile-test", ".csv")
 		println("Creating temporary data file "+dataFile1.getAbsolutePath())
 		val writer = new FileWriter(dataFile1)
-		Range(0, 8).foreach(n =>
-			writer.write("%f,%f\n".format(n.toDouble, (7-n).toDouble))
+		Range(0, 12).foreach(n =>
+			if (n < 8) {
+				// Good data
+				writer.write("%f,%f\n".format(n.toDouble, (7-n).toDouble))
+			} else {
+				// Bad data
+				writer.write("a,b)\n")
+			}
 		)
 		writer.flush()
 		writer.close()


### PR DESCRIPTION
CSVReader wasn't checking lines to filter out bad ones.

I also put in some filters in the accumulator binning in case there are errors there (as per the way the issue was written, as per what I suggested to Rob the issue probably was), but that's tough to check - our CSV reader and parser makes it hard to get bad data that far.

fixes #147 
