### PR TITLE
Update Quick Start and Download pages to reference new Quick Start WAR file

### DIFF
--- a/docs/src/docs/development/quickstart/readme.md
+++ b/docs/src/docs/development/quickstart/readme.md
@@ -103,8 +103,8 @@ If you later intend to create Aperture Tiles projects using particularly large d
 
 Save and unzip the following Aperture Tiles distributions available on the [Download](../../../download/) section of this website. You will use these utilities to create the Julia set data and provision the example Aperture Tiles project.
 
-- [Tile Generator](../../../download/#tile-generator): Enables you to create the Julia set data and generate a set of tiles that can be viewed in the Tile Quick Start template
-- [Tile Quick Start Application](../../../download/#tile-quick-start-template): An example Tile Client Application that you can quickly copy and deploy to your web server after minimal modification
+- [Tile Generator](../../../download/#tile-generator): Enables you to create the Julia set data and generate a set of tiles that can be viewed in the Tile Quick Start Application
+- [Tile Quick Start Application](../../../download/#tile-quick-start-application): An example Tile Client application that you can quickly copy and deploy to your web server after minimal modification
 
 The full Aperture Tiles source code, available for download from [GitHub](https://github.com/oculusinfo/aperture-tiles/tree/master), is not required for this example. For information on full installations of Aperture Tiles, see the [Installation](../installation/) page.
 
@@ -222,7 +222,7 @@ The `oculus.binning.prefix` value is only included if you set it in the property
 
 ## <a name="tile-server-configuration"></a> Tile Server Configuration ##
 
-For this example, a preconfigured example server application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-template)). The server renders the layers that are displayed in your Aperture Tiles visualization and passes them to the client.
+For this example, a preconfigured example server application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-application)). The server renders the layers that are displayed in your Aperture Tiles visualization and passes them to the client.
 
 If you stored your Avro tiles on your local filesystem, zip the *julia.x.y.v* directory produced during the Tile Generation stage and add it to the *WEB-INF/classes/* directory of the Tile Quick Start Application.
 
@@ -249,15 +249,15 @@ For information on additional layer properties you can specify, see the Layers s
 
 ## <a name="tile-client-application"></a> Tile Client Application ##
 
-For this example, a preconfigured example client application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-template)). The client displays the base map or plot and any layers passed in from the server.
+For this example, a preconfigured example client application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-application)). The client displays the base map or plot and any layers passed in from the server.
 
 For information on additional map properties you can specify, see the Maps section of the [Configuration](../configuration/#maps) topic, which describes how to configure settings such as boundaries and axes. 
 
 ## <a name="deployment"></a> Deployment ##
 
-Once you have finished configuring the map and layer properties, copy *tile-quickstart.war* to your web server's (e.g., Apache Tomcat or Jetty) *webapps/* directory.
+Once you have finished configuring the map and layer properties, copy the *tile-quickstart.war* to the *webapps/* directory or your web server (e.g., Apache Tomcat or Jetty).
 
-Once your server is running, you can access the application at `http://localhost:8080/julia-demo` from any web browser to view the Julia set data plotted on an X/Y chart with six layers of zoom available.
+Once your server is running, use your web browser to access the application at `http://localhost:8080/julia-demo`. The Julia set application data is plotted on an X/Y chart with six layers of zoom available.
 
 ## Next Steps ##
 

--- a/docs/src/docs/development/quickstart/readme.md
+++ b/docs/src/docs/development/quickstart/readme.md
@@ -104,7 +104,7 @@ If you later intend to create Aperture Tiles projects using particularly large d
 Save and unzip the following Aperture Tiles distributions available on the [Download](../../../download/) section of this website. You will use these utilities to create the Julia set data and provision the example Aperture Tiles project.
 
 - [Tile Generator](../../../download/#tile-generator): Enables you to create the Julia set data and generate a set of tiles that can be viewed in the Tile Quick Start template
-- [Tile Quick Start Template](../../../download/#tile-quick-start-template): An example Tile Client that you can quickly copy and deploy to your web server after minimal modification
+- [Tile Quick Start Application](../../../download/#tile-quick-start-template): An example Tile Client Application that you can quickly copy and deploy to your web server after minimal modification
 
 The full Aperture Tiles source code, available for download from [GitHub](https://github.com/oculusinfo/aperture-tiles/tree/master), is not required for this example. For information on full installations of Aperture Tiles, see the [Installation](../installation/) page.
 
@@ -222,21 +222,21 @@ The `oculus.binning.prefix` value is only included if you set it in the property
 
 ## <a name="tile-server-configuration"></a> Tile Server Configuration ##
 
-For this example, a preconfigured example server application has been provided as part of the Tile Quick Start Template ([tile-quickstart.zip](../../../download/#tile-quick-start-template)). The server renders the layers that are displayed in your Aperture Tiles visualization and passes them to the client.
+For this example, a preconfigured example server application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-template)). The server renders the layers that are displayed in your Aperture Tiles visualization and passes them to the client.
 
-If you stored your Avro tiles on your local filesystem, zip the *julia.x.y.v* directory produced during the Tile Generation stage and add it to the *src/main/resources/* directory of the Tile Quick Start Template.
+If you stored your Avro tiles on your local filesystem, zip the *julia.x.y.v* directory produced during the Tile Generation stage and add it to the *WEB-INF/classes/* directory of the Tile Quick Start Application.
 
-For typical Aperture Tiles projects, you will also need to edit the *src/main/webapp/WEB-INF/***web.xml** and *src/main/resources/***tile.properties** files in the Tile Quick Start Template. For more information on editing these files, see the [Configuration](../configuration/) topic on this website.
+For typical Aperture Tiles projects, you will also need to edit the */WEB-INF/***web.xml** and *WEB-INF/classes/***tile.properties** files in the Tile Quick Start Application. For more information on editing these files, see the [Configuration](../configuration/) topic on this website.
 
 ### Layer Properties ###
 
-Layer properties (within the **tile-quickstart.zip** at *src/main/resources/layers/***julia-layer.json**) specify the layers that can be overlaid on your base map or plot. 
+Layer properties (within the **tile-quickstart.war** at *WEB-INF/classes/layers/***julia-layer.json**) specify the layers that can be overlaid on your base map or plot. 
 
 For this example, you only need to edit the layer properties file if you saved your Avro tiles to HBase. Otherwise, you can skip ahead to the configuration of the [Tile Client Application](#tile-client-application). 
 
 <h6 class="procedure">To edit the layer properties for your project</h6>
 
-1. Access the *src/main/resources/layers/***julia-layer.json** file.
+1. Access the *WEB-INF/classes/layers/***julia-layer.json** file.
 2. Make sure the **id** property under the `private` node matches the name given to the HBase table name to which your Avro tiles were generated. For the Julia set example, this should be *julia.x.y.v*.
 3. Clear the existing attributes under the `pyramidio` node and add the following HBase connection details:
 	- `type`: Enter *hbase*
@@ -249,32 +249,13 @@ For information on additional layer properties you can specify, see the Layers s
 
 ## <a name="tile-client-application"></a> Tile Client Application ##
 
-For this example, a preconfigured example client application has been provided as part of the Tile Quick Start Template ([tile-quickstart.zip](../../../download/#tile-quick-start-template)). The client displays the base map or plot and any layers passed in from the server.
-
-To configure the tile client application to display the Avro files containing your source data, you must edit the map properties (within the **tile-quickstart.zip** at *src/main/webapp/***app.js**) to specify the attributes of the base map or plot on which your data is displayed.
-
-### Map Properties ###
-
-<h6 class="procedure">To edit the map properties for your project</h6>
-
-1. Open the **app.js** file in the the extracted Tile Quick Start template.
-2. Edit the *serverLayer* to pass in the name given to the directory (file system directory or HBase table name) to which your Avro tiles were generated. For the Julia set example, this should be *julia.x.y.v*.
-3. Save the file.
+For this example, a preconfigured example client application has been provided as part of the Tile Quick Start Application ([tile-quickstart.war](../../../download/#tile-quick-start-template)). The client displays the base map or plot and any layers passed in from the server.
 
 For information on additional map properties you can specify, see the Maps section of the [Configuration](../configuration/#maps) topic, which describes how to configure settings such as boundaries and axes. 
 
 ## <a name="deployment"></a> Deployment ##
 
-Once you have finished configuring the map and layer properties, copy the *tile-quickstart/* folder to your web server's (e.g., Apache Tomcat or Jetty) *webapps/* directory.
-
-**NOTE**: If you have the Aperture Tiles source code, you can also use Gradle to deploy a Jetty server:
-
-1. Copy the *tile-quickstart/* folder to the root `aperture-tiles` directory.
-2. Run the following command:
-
-```bash
-./gradlew jettyRun
-```
+Once you have finished configuring the map and layer properties, copy *tile-quickstart.war* to your web server's (e.g., Apache Tomcat or Jetty) *webapps/* directory.
 
 Once your server is running, you can access the application at `http://localhost:8080/julia-demo` from any web browser to view the Julia set data plotted on an X/Y chart with six layers of zoom available.
 

--- a/docs/src/download/readme.md
+++ b/docs/src/download/readme.md
@@ -23,10 +23,10 @@ For information on full installations of Aperture Tiles (along with Aperture JS)
 
 The following pre-built distribution can be used to quickly generate and display tiles without having to build the software. See the [Quick Start](../docs/development/quickstart) documentation to help you quickly learn how to process a data set, transform it and create an Aperture Tiles project that allows you to visualize it in a web browser.
 
-- <a name="tile-generator"></a>**Tile Generator**: Enables you to generate a set of tiles that can be viewed using the template Tile Client available below. This version was built for Apache Spark 1.1.1 and CDH 4.6.
+- <a name="tile-generator"></a>**Tile Generator**: Enables you to generate a set of tiles that can be viewed using the Tile Client Application available below. This version was built for Apache Spark 1.1.1 and CDH 4.6.
 	<br/><br/><a href="http://assets.oculusinfo.com/tiles/downloads/tile-generator-0.5-cdh4.6.0.zip" class="download-link">Tile Generator</a><br/><br/>
-- <a name="tile-quick-start-template"></a>**Tile Quick Start Template**: An example Tile Client that you can quickly copy and deploy to your web server after minimal modification to display tiles in a browser.
-	<br/><br/><a href="http://assets.oculusinfo.com/tiles/downloads/tile-quickstart-0.5.zip" class="download-link">Tile Quick Start Template</a>
+- <a name="tile-quick-start-application"></a>**Tile Quick Start Application**: An example Tile Client application to display tiles in a browser. You can quickly copy and deploy this application to your web server after minimal modification.
+	<br/><br/><a href="http://assets.oculusinfo.com/tiles/downloads/tile-quickstart-0.5.war" class="download-link">Tile Quick Start Application</a>
 
 <div class="git">
 	<h2>Interested in Learning More?</h2>


### PR DESCRIPTION
Replaces references to "Tile Quick Start Template" with "Tile Quick Start Application" to address changes introduced in 03ff62114ce902aa37355d965546b656b583a190. Also replaces Tile Quick Start Application download link to point to WAR file.