### PR TITLE
NumberConverter.asDouble does not handle null values

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
@@ -46,22 +46,22 @@ trait TimeIndexScheme[T] extends IndexScheme[T] {
 }
 
 trait NumberConverter {
-  @throws(classOf[IllegalArgumentException])
+	@throws(classOf[IllegalArgumentException])
 	def asDouble (x: Any): Double = {
-    if (x == null) {
-      throw new IllegalArgumentException
-    } else {
-      x match {
-        case c: Byte => c.toDouble
-        case c: Short => c.toDouble
-        case c: Int => c.toDouble
-        case c: Long => c.toDouble
-        case c: Float => c.toDouble
-        case c: Double => c.toDouble
-        case c: Date => c.getTime
-      }
-    }
-  }
+		if (x == null) {
+			throw new IllegalArgumentException
+		} else {
+			x match {
+				case c: Byte => c.toDouble
+				case c: Short => c.toDouble
+				case c: Int => c.toDouble
+				case c: Long => c.toDouble
+				case c: Float => c.toDouble
+				case c: Double => c.toDouble
+				case c: Date => c.getTime
+			}
+		}
+	}
 }
 
 class CartesianSchemaIndexScheme extends IndexScheme[Seq[Any]] with NumberConverter with Serializable {

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
@@ -25,12 +25,12 @@
 
 package com.oculusinfo.tilegen.tiling
 
-
 import java.util.Date
 
-import com.oculusinfo.binning.impl.AOITilePyramid
-
+import scala.Range
 import scala.collection.mutable.ArrayBuffer
+
+import com.oculusinfo.binning.impl.AOITilePyramid
 
 
 trait IndexScheme[T] {
@@ -48,7 +48,7 @@ trait TimeIndexScheme[T] extends IndexScheme[T] {
 trait NumberConverter {
 	def asDouble (x: Any): Double =
 		x match {
-      case c if(c == null) => null.asInstanceOf[Double]
+			case null => null.asInstanceOf[Double]
 			case c: Byte => c.toDouble
 			case c: Short => c.toDouble
 			case c: Int => c.toDouble

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
@@ -46,17 +46,22 @@ trait TimeIndexScheme[T] extends IndexScheme[T] {
 }
 
 trait NumberConverter {
-	def asDouble (x: Any): Double =
-		x match {
-			case null => null.asInstanceOf[Double]
-			case c: Byte => c.toDouble
-			case c: Short => c.toDouble
-			case c: Int => c.toDouble
-			case c: Long => c.toDouble
-			case c: Float => c.toDouble
-			case c: Double => c.toDouble
-			case c: Date => c.getTime
-		}
+  @throws(classOf[IllegalArgumentException])
+	def asDouble (x: Any): Double = {
+    if (x == null) {
+      throw new IllegalArgumentException
+    } else {
+      x match {
+        case c: Byte => c.toDouble
+        case c: Short => c.toDouble
+        case c: Int => c.toDouble
+        case c: Long => c.toDouble
+        case c: Float => c.toDouble
+        case c: Double => c.toDouble
+        case c: Date => c.getTime
+      }
+    }
+  }
 }
 
 class CartesianSchemaIndexScheme extends IndexScheme[Seq[Any]] with NumberConverter with Serializable {

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
@@ -48,6 +48,7 @@ trait TimeIndexScheme[T] extends IndexScheme[T] {
 trait NumberConverter {
 	def asDouble (x: Any): Double =
 		x match {
+      case c if(c == null) => null.asInstanceOf[Double]
 			case c: Byte => c.toDouble
 			case c: Short => c.toDouble
 			case c: Int => c.toDouble

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/IndexingScheme.scala
@@ -48,18 +48,15 @@ trait TimeIndexScheme[T] extends IndexScheme[T] {
 trait NumberConverter {
 	@throws(classOf[IllegalArgumentException])
 	def asDouble (x: Any): Double = {
-		if (x == null) {
-			throw new IllegalArgumentException
-		} else {
-			x match {
-				case c: Byte => c.toDouble
-				case c: Short => c.toDouble
-				case c: Int => c.toDouble
-				case c: Long => c.toDouble
-				case c: Float => c.toDouble
-				case c: Double => c.toDouble
-				case c: Date => c.getTime
-			}
+		x match {
+			case null => throw new IllegalArgumentException
+			case c: Byte => c.toDouble
+			case c: Short => c.toDouble
+			case c: Int => c.toDouble
+			case c: Long => c.toDouble
+			case c: Float => c.toDouble
+			case c: Double => c.toDouble
+			case c: Date => c.getTime
 		}
 	}
 }

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
@@ -31,11 +31,9 @@ import org.scalatest.FunSuite
 class IndexingSchemeTests extends FunSuite {
 	test("Test null conversion") {
 		val converter = new Object with NumberConverter
-		try {
+		intercept[IllegalArgumentException] {
 			converter.asDouble(null)
 			fail
-		} catch {
-			case e: Any => assert(e.isInstanceOf[IllegalArgumentException])
 		}
 	}
 

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
@@ -31,12 +31,12 @@ import org.scalatest.FunSuite
 class IndexingSchemeTests extends FunSuite {
 	test("Test null conversion") {
 		val converter = new Object with NumberConverter
-    try {
-      converter.asDouble(null)
-      fail
-    } catch {
-      case e: Any => assert(e.isInstanceOf[IllegalArgumentException])
-    }
+		try {
+			converter.asDouble(null)
+			fail
+		} catch {
+			case e: Any => assert(e.isInstanceOf[IllegalArgumentException])
+		}
 	}
 
 	test("Test cartesian indices on non-doubles") {

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
@@ -31,7 +31,12 @@ import org.scalatest.FunSuite
 class IndexingSchemeTests extends FunSuite {
 	test("Test null conversion") {
 		val converter = new Object with NumberConverter
-		assert(0.0 === converter.asDouble(null))
+    try {
+      converter.asDouble(null)
+      fail
+    } catch {
+      case e: Any => assert(e.isInstanceOf[IllegalArgumentException])
+    }
 	}
 
 	test("Test cartesian indices on non-doubles") {

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/IndexingSchemeTests.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.tilegen.tiling
+
+import org.scalatest.FunSuite
+
+
+
+class IndexingSchemeTests extends FunSuite {
+	test("Test null conversion") {
+		val converter = new Object with NumberConverter
+		assert(0.0 === converter.asDouble(null))
+	}
+
+	test("Test cartesian indices on non-doubles") {
+		val scheme = new CartesianSchemaIndexScheme
+		assert(1.0 === scheme.toCartesian(Seq[Any](1, 2))._1)
+		assert(2.0 === scheme.toCartesian(Seq[Any](1, 2L))._2)
+		assert(3.5 === scheme.toCartesian(Seq[Any](3.5f, 3.4f))._1)
+		assert(6.0 === scheme.toCartesian(Seq[Any](1, 6.toByte))._2)
+		assert(7.0 === scheme.toCartesian(Seq[Any](7.toShort, 8.toShort))._1)
+		assert(456789.0 === scheme.toCartesian(Seq[Any](1, new java.util.Date(456789L)))._2)
+	}
+}


### PR DESCRIPTION
NumberConvert.asDouble should throw an IllegalArgumentException when trying to convert a null input Any into a Double instead of throwing a scala.MatchError: null. Fixes #155